### PR TITLE
fix gae home for gae 1.9.17

### DIFF
--- a/gwtp-samples/pom.xml
+++ b/gwtp-samples/pom.xml
@@ -93,7 +93,7 @@
 
         <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
         <gae.home>
-            ${settings.localRepository}/com/google/appengine/appengine-java-sdk/${gae.version}/appengine-java-sdk-${gae.version}
+            ${settings.localRepository}/com/google/appengine/appengine-java-sdk/${gae.version}/appengine-java-sdk/appengine-java-sdk-${gae.version}
         </gae.home>
     </properties>
 


### PR DESCRIPTION
The last appengine release changed its directory structure.  And then they rereleased and broke it in a different way with a 1.9.17a release.  This will probably need to be fixed again when the project is upgraded to 1.9.18.