### PR TITLE
Update to 1.5-snapshot changes.

### DIFF
--- a/carstore/pom.xml
+++ b/carstore/pom.xml
@@ -46,7 +46,7 @@
         <gwt-maven-plugin.version>2.7.0</gwt-maven-plugin.version>
         <maven-checkstyle-plugin.version>2.14</maven-checkstyle-plugin.version>
 
-        <arcbees-checkstyle.version>1.1</arcbees-checkstyle.version>
+        <arcbees-checkstyle.version>1.2</arcbees-checkstyle.version>
         <checkstyle.version>6.3</checkstyle.version>
 
         <!-- Settings -->

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationDesktopModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationDesktopModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationMobileModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationMobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationMobileView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationTabletModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationTabletModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/ApplicationView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/UnauthorizedModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/UnauthorizedModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/UnauthorizedPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/UnauthorizedPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/UnauthorizedView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/UnauthorizedView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsDesktopModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsDesktopModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsMobileModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsMobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsMobileView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/CarsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarMobileView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarPresenterFactory.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarPresenterFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarPresenterProvider.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarPresenterProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarProxyFactory.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarProxyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarProxyImpl.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarProxyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarProxyImplFactory.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarProxyImplFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarRenderer.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/CarView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/RootCarPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/RootCarPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/RootCarView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/RootCarView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/CloseTabEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/CloseTabEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTab.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTabEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTabEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTabPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTabPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTabView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationTabView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/NavigationUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/Tab.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/navigation/Tab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/widget/CarPropertiesEditor.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/car/widget/CarPropertiesEditor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/event/CarAddedEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/event/CarAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/renderer/CarCell.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/cars/renderer/CarCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/ActionBarEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/ActionBarEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/ActionBarVisibilityEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/ActionBarVisibilityEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/ChangeActionBarEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/ChangeActionBarEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/DisplayMessageEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/DisplayMessageEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/GoBackEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/GoBackEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/UserLoginEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/event/UserLoginEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginMobileModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginMobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginMobileView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/login/LoginView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerDetailPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerDetailPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerDetailUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerDetailUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerDetailView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerDetailView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerMobileModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerMobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerMobileView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ManufacturerView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/event/ManufacturerAddedEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/event/ManufacturerAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/renderer/ManufacturerCell.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/renderer/ManufacturerCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/EditManufacturerPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/EditManufacturerPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/EditManufacturerUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/EditManufacturerUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/EditManufacturerView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/EditManufacturerView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/ManufacturerRenderer.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/manufacturer/ui/ManufacturerRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingDetailPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingDetailPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingDetailUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingDetailUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingDetailView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingDetailView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingMobileModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingMobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingMobileView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/RatingView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/event/RatingAddedEvent.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/event/RatingAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/renderer/RatingCell.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/renderer/RatingCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/renderer/RatingCellFactory.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/renderer/RatingCellFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/EditRatingPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/EditRatingPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/EditRatingUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/EditRatingUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/EditRatingView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/EditRatingView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/RatingColumnsDefinition.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/rating/ui/RatingColumnsDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportMobileModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportMobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportMobileView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/ReportView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/renderer/ReportCell.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/report/renderer/ReportCell.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/stats/StatisticsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/ui/ShowMorePagerPanel.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/ui/ShowMorePagerPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/WidgetModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/WidgetModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/header/HeaderPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/header/HeaderPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/header/HeaderUiHandlers.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/header/HeaderUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/header/HeaderView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/header/HeaderView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/Message.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessageCloseDelay.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessageCloseDelay.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessageStyle.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessageStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessagesModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessagesModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessagesPresenter.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessagesPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessagesView.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/MessagesView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/ui/MessageWidget.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/ui/MessageWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/ui/MessageWidgetFactory.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/application/widget/message/ui/MessageWidgetFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/columninitializer/Column.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/columninitializer/Column.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/columninitializer/ColumnInitializer.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/columninitializer/ColumnInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/columninitializer/ColumnsDefinition.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/columninitializer/ColumnsDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/debug/DebugIds.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/debug/DebugIds.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rest/AppRestDispatchHooks.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rest/AppRestDispatchHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rest/CarDeleteInterceptor.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rest/CarDeleteInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rest/RestInterceptorRegistry.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rest/RestInterceptorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rpc/AppRpcDispatchHooks.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rpc/AppRpcDispatchHooks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rpc/LogInInterceptor.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rpc/LogInInterceptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rpc/RpcInterceptorRegistry.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/dispatch/rpc/RpcInterceptorRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/CarStoreModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/CarStoreModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/DesktopModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/DesktopModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/MobileModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/MobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/PhoneGapLocalModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/PhoneGapLocalModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/PhoneGapModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/PhoneGapModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/PhoneGapRemoteModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/PhoneGapRemoteModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/ResourceLoader.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/ResourceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/SharedModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/SharedModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/SharedModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/SharedModule.java
@@ -24,34 +24,31 @@ import com.gwtplatform.carstore.client.place.NameTokens;
 import com.gwtplatform.carstore.client.security.SecurityModule;
 import com.gwtplatform.dispatch.rest.client.gin.RestDispatchAsyncModule;
 import com.gwtplatform.dispatch.rpc.client.gin.RpcDispatchAsyncModule;
-import com.gwtplatform.mvp.client.annotations.DefaultPlace;
-import com.gwtplatform.mvp.client.annotations.ErrorPlace;
-import com.gwtplatform.mvp.client.annotations.UnauthorizedPlace;
 import com.gwtplatform.mvp.client.gin.AbstractPresenterModule;
 import com.gwtplatform.mvp.client.gin.DefaultModule;
 
 public class SharedModule extends AbstractPresenterModule {
     @Override
     protected void configure() {
-        install(new DefaultModule());
-        install(new SecurityModule());
-
+        // GWTP libraries
+        install(new DefaultModule.Builder()
+                .defaultPlace(NameTokens.LOGIN)
+                .errorPlace(NameTokens.LOGIN)
+                .unauthorizedPlace(NameTokens.UNAUTHORIZED)
+                .build());
         install(new RestDispatchAsyncModule.Builder()
                 .dispatchHooks(AppRestDispatchHooks.class)
                 .interceptorRegistry(RestInterceptorRegistry.class)
                 .build());
-
         install(new RpcDispatchAsyncModule.Builder()
                 .dispatchHooks(AppRpcDispatchHooks.class)
                 .interceptorRegistry(RpcInterceptorRegistry.class)
                 .build());
 
-        // DefaultPlaceManager Places
-        bindConstant().annotatedWith(DefaultPlace.class).to(NameTokens.LOGIN);
-        bindConstant().annotatedWith(ErrorPlace.class).to(NameTokens.LOGIN);
-        bindConstant().annotatedWith(UnauthorizedPlace.class).to(NameTokens.UNAUTHORIZED);
+        // CarStore modules
+        install(new SecurityModule());
 
-        // Load and inject CSS resources
+        // Load and inject CSS resources at startup
         bind(ResourceLoader.class).asEagerSingleton();
     }
 }

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/gin/TabletModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/gin/TabletModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/place/NameTokens.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/place/NameTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/place/ParameterTokens.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/place/ParameterTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/AppResources.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/AppResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/CarMessages.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/CarMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/EditManufacturerMessages.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/EditManufacturerMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/EditRatingMessages.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/EditRatingMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/HeaderMessages.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/HeaderMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/LoginMessages.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/LoginMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/MobileDataListStyle.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/MobileDataListStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/MobileNavigationListStyle.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/MobileNavigationListStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/NavigationListStyle.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/NavigationListStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/resources/WidgetResources.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/resources/WidgetResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/security/CurrentUser.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/security/CurrentUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/security/LoggedInGatekeeper.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/security/LoggedInGatekeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/security/SecurityModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/security/SecurityModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/util/AbstractAsyncCallback.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/util/AbstractAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/util/ErrorHandlerAsyncCallback.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/util/ErrorHandlerAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/util/exceptiontranslators/ForeignTranslator.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/util/exceptiontranslators/ForeignTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/util/exceptiontranslators/NotNullTranslator.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/util/exceptiontranslators/NotNullTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/client/util/exceptiontranslators/Translator.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/client/util/exceptiontranslators/Translator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/AbstractVelocityGenerator.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/AbstractVelocityGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/ColumnTuple.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/ColumnTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/ColumnsInitializerDefinitions.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/ColumnsInitializerDefinitions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/ColumnsInitializerGenerator.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/ColumnsInitializerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/GeneratorUtil.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/GeneratorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/RebindModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/RebindModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/VelocityColumnsInitializerGenerator.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/VelocityColumnsInitializerGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/rebind/VelocityProperties.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/rebind/VelocityProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/DevBootStrapper.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/DevBootStrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/ApiModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/ApiModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/CarResourceImpl.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/CarResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/CarsResourceImpl.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/CarsResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/JacksonProvider.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/JacksonProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/ManufacturersResourceImpl.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/ManufacturersResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/RatingResourceImpl.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/RatingResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/ResourcesFactory.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/ResourcesFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/SessionResourceImpl.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/SessionResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/api/StatisticsResourceImpl.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/api/StatisticsResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -20,9 +20,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
@@ -32,6 +35,8 @@ import com.gwtplatform.carstore.shared.api.ApiParameters;
 import com.gwtplatform.carstore.shared.api.ApiPaths;
 
 @Path(ApiPaths.STATS)
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class StatisticsResourceImpl {
     private final SimpleDateFormat dateFormat = new SimpleDateFormat(ApiParameters.DATE_FORMAT);
 

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/AuthenticationException.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/AuthenticationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/Authenticator.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/Authenticator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/BCryptPasswordSecurity.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/BCryptPasswordSecurity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/CurrentUserDtoProvider.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/CurrentUserDtoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/PasswordSecurity.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/PasswordSecurity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/SecurityParameters.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/authentication/SecurityParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/BaseDao.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/BaseDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/CarDao.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/CarDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/CarPropertiesDao.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/CarPropertiesDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/ManufacturerDao.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/ManufacturerDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/RatingDao.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/RatingDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/UserDao.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/UserDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/UserSessionDao.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/UserSessionDao.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/Car.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/Car.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/CarProperties.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/CarProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/Manufacturer.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/Manufacturer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/Rating.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/Rating.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/User.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/UserSession.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/domain/UserSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/objectify/Deref.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/objectify/Deref.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dao/objectify/OfyService.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dao/objectify/OfyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dispatch/DispatchModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dispatch/DispatchModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/dispatch/LogInHandler.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/dispatch/LogInHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/guice/DispatchServletModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/guice/DispatchServletModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/guice/GuiceServletConfig.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/guice/GuiceServletConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/guice/ServerModule.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/guice/ServerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/server/service/ReportService.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/server/service/ReportService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/ApiParameters.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/ApiParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/ApiPaths.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/ApiPaths.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/CarResource.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/CarResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/CarsResource.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/CarsResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/ManufacturersResource.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/ManufacturersResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/RatingResource.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/RatingResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/SessionResource.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/SessionResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/api/StatisticsResource.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/api/StatisticsResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -18,9 +18,12 @@ package com.gwtplatform.carstore.shared.api;
 
 import java.util.Date;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 import com.gwtplatform.dispatch.rest.shared.DateFormat;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
@@ -30,6 +33,9 @@ import static com.gwtplatform.carstore.shared.api.ApiParameters.DATE_FORMAT;
 import static com.gwtplatform.carstore.shared.api.ApiPaths.STATS;
 
 @Path(STATS)
+// TODO: Use text/plain when the default serialization library is coded
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public interface StatisticsResource {
     // This method is intentionally left out as a RestAction to ensure it's properly handled.
     @GET

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dispatch/ActionType.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dispatch/ActionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dispatch/LogInAction.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dispatch/LogInAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dispatch/LogInResult.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dispatch/LogInResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/BaseEntity.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/BaseEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/CarDto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/CarDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/CarPropertiesDto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/CarPropertiesDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/CurrentUserDto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/CurrentUserDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/Dto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/Dto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/ManufacturerDto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/ManufacturerDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/ManufacturerRatingDto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/ManufacturerRatingDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/RatingDto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/RatingDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/UserDto.java
+++ b/carstore/src/main/java/com/gwtplatform/carstore/shared/dto/UserDto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/client/application/CarsPresenterTest.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/client/application/CarsPresenterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/client/application/testutils/PresenterTestModule.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/client/application/testutils/PresenterTestModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/client/application/testutils/PresenterWidgetTestBase.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/client/application/testutils/PresenterWidgetTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/CucumberInjectorSource.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/CucumberInjectorSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/CucumberModule.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/CucumberModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/RunCucumberIT.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/RunCucumberIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/ApplicationPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/ApplicationPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/BasePage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/BasePage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/PageWithEditTable.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/PageWithEditTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/UnauthorizedPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/UnauthorizedPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/cars/CarsPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/cars/CarsPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/cars/EditCarsPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/cars/EditCarsPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/login/LoginPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/login/LoginPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/manufacturers/ManufacturersEditPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/manufacturers/ManufacturersEditPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/manufacturers/ManufacturersPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/manufacturers/ManufacturersPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/ratings/RatingPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/ratings/RatingPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/reports/ReportPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/reports/ReportPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/stats/StatsPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/stats/StatsPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/widgets/HeaderWidgetPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/widgets/HeaderWidgetPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/widgets/MessageWidgetPage.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/application/widgets/MessageWidgetPage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/BasicStepdefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/BasicStepdefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/BasicStepdefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/BasicStepdefs.java
@@ -33,8 +33,9 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
 
-import static com.gwtplatform.carstore.client.debug.DebugIds.DBG_LOGIN;
 import static org.junit.Assert.assertTrue;
+
+import static com.gwtplatform.carstore.client.debug.DebugIds.DBG_LOGIN;
 
 @ScenarioScoped
 public class BasicStepdefs {

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/CarsStepdefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/CarsStepdefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/LoginStepdefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/LoginStepdefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/ManufacturersStepDefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/ManufacturersStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/RatingStepdefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/RatingStepdefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/ReportStepDefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/ReportStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/StatsStepDefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/StatsStepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/StepDefs.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/stepdefs/StepDefs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/util/ByDebugId.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/util/ByDebugId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/cucumber/util/TestParameters.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/cucumber/util/TestParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/server/authentication/AuthenticatorTest.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/server/authentication/AuthenticatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/server/authentication/BCryptPasswordSecurityTest.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/server/authentication/BCryptPasswordSecurityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/carstore/src/test/java/com/gwtplatform/carstore/server/authentication/CurrentUserDtoProviderTest.java
+++ b/carstore/src/test/java/com/gwtplatform/carstore/server/authentication/CurrentUserDtoProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/pom.xml
+++ b/gwtp-samples/gwtp-sample-basic-spring/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.gwtplatform</groupId>
         <artifactId>gwtp-samples</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>gwtp-sample-basic-spring</artifactId>

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationModule.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationPresenter.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationView.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/ApplicationView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponseModule.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponseModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponsePresenter.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponsePresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponseUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponseUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponseView.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/application/response/ResponseView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/gin/ClientModule.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/gin/ClientModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -18,13 +18,9 @@ package com.gwtplatform.samples.basicspring.client.gin;
 
 import com.gwtplatform.dispatch.rpc.client.gin.RpcDispatchAsyncModule;
 import com.gwtplatform.dispatch.shared.SecurityCookie;
-import com.gwtplatform.mvp.client.annotations.DefaultPlace;
-import com.gwtplatform.mvp.client.annotations.ErrorPlace;
 import com.gwtplatform.mvp.client.annotations.GaAccount;
-import com.gwtplatform.mvp.client.annotations.UnauthorizedPlace;
 import com.gwtplatform.mvp.client.gin.AbstractPresenterModule;
 import com.gwtplatform.mvp.client.gin.DefaultModule;
-import com.gwtplatform.mvp.client.proxy.DefaultPlaceManager;
 import com.gwtplatform.samples.basicspring.client.application.ApplicationModule;
 import com.gwtplatform.samples.basicspring.client.place.NameTokens;
 import com.gwtplatform.samples.basicspring.client.resources.ResourceLoader;
@@ -35,13 +31,13 @@ public class ClientModule extends AbstractPresenterModule {
 
     @Override
     protected void configure() {
-        install(new DefaultModule(DefaultPlaceManager.class));
+        install(new DefaultModule.Builder()
+                .defaultPlace(NameTokens.home)
+                .errorPlace(NameTokens.home)
+                .unauthorizedPlace(NameTokens.home)
+                .build());
         install(new RpcDispatchAsyncModule());
         install(new ApplicationModule());
-
-        bindConstant().annotatedWith(DefaultPlace.class).to(NameTokens.home);
-        bindConstant().annotatedWith(ErrorPlace.class).to(NameTokens.home);
-        bindConstant().annotatedWith(UnauthorizedPlace.class).to(NameTokens.home);
 
         bindConstant().annotatedWith(GaAccount.class).to(ANALYTICS_ACCOUNT);
 

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/place/NameTokens.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/place/NameTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/place/TokenParameters.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/place/TokenParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/resources/AppResources.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/resources/AppResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/resources/ResourceLoader.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/client/resources/ResourceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/server/dispatch/SendTextToServerHandler.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/server/dispatch/SendTextToServerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/server/spring/ServerModule.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/server/spring/ServerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/shared/FieldVerifier.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/shared/FieldVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/shared/dispatch/SendTextToServerAction.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/shared/dispatch/SendTextToServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/shared/dispatch/SendTextToServerResult.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/main/java/com/gwtplatform/samples/basicspring/shared/dispatch/SendTextToServerResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/test/java/com/gwtplatform/samples/basicspring/client/SandboxGwtTest.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/test/java/com/gwtplatform/samples/basicspring/client/SandboxGwtTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic-spring/src/test/java/com/gwtplatform/samples/basicspring/client/SandboxJukitoTest.java
+++ b/gwtp-samples/gwtp-sample-basic-spring/src/test/java/com/gwtplatform/samples/basicspring/client/SandboxJukitoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/pom.xml
+++ b/gwtp-samples/gwtp-sample-basic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.gwtplatform</groupId>
         <artifactId>gwtp-samples</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>gwtp-sample-basic</artifactId>

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationModule.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationPresenter.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationView.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/ApplicationView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponseModule.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponseModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponsePresenter.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponsePresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponseUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponseUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponseView.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/application/response/ResponseView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/gin/ClientModule.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/gin/ClientModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -17,10 +17,7 @@
 package com.gwtplatform.samples.basic.client.gin;
 
 import com.gwtplatform.dispatch.rpc.client.gin.RpcDispatchAsyncModule;
-import com.gwtplatform.mvp.client.annotations.DefaultPlace;
-import com.gwtplatform.mvp.client.annotations.ErrorPlace;
 import com.gwtplatform.mvp.client.annotations.GaAccount;
-import com.gwtplatform.mvp.client.annotations.UnauthorizedPlace;
 import com.gwtplatform.mvp.client.gin.AbstractPresenterModule;
 import com.gwtplatform.mvp.client.gin.DefaultModule;
 import com.gwtplatform.samples.basic.client.application.ApplicationModule;
@@ -32,13 +29,13 @@ public class ClientModule extends AbstractPresenterModule {
 
     @Override
     protected void configure() {
-        install(new DefaultModule());
+        install(new DefaultModule.Builder()
+                .defaultPlace(NameTokens.home)
+                .errorPlace(NameTokens.home)
+                .unauthorizedPlace(NameTokens.home)
+                .build());
         install(new RpcDispatchAsyncModule());
         install(new ApplicationModule());
-
-        bindConstant().annotatedWith(DefaultPlace.class).to(NameTokens.home);
-        bindConstant().annotatedWith(ErrorPlace.class).to(NameTokens.home);
-        bindConstant().annotatedWith(UnauthorizedPlace.class).to(NameTokens.home);
 
         bindConstant().annotatedWith(GaAccount.class).to(ANALYTICS_ACCOUNT);
 

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/place/NameTokens.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/place/NameTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/place/TokenParameters.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/place/TokenParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/resources/AppResources.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/resources/AppResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/resources/ResourceLoader.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/client/resources/ResourceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/dispatch/SendTextToServerHandler.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/dispatch/SendTextToServerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/guice/DispatchServletModule.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/guice/DispatchServletModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/guice/GuiceServletConfig.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/guice/GuiceServletConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/guice/ServerModule.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/server/guice/ServerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/shared/FieldVerifier.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/shared/FieldVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/shared/dispatch/SendTextToServerAction.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/shared/dispatch/SendTextToServerAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/shared/dispatch/SendTextToServerResult.java
+++ b/gwtp-samples/gwtp-sample-basic/src/main/java/com/gwtplatform/samples/basic/shared/dispatch/SendTextToServerResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/test/java/com/gwtplatform/samples/basic/client/SandboxGwtTest.java
+++ b/gwtp-samples/gwtp-sample-basic/src/test/java/com/gwtplatform/samples/basic/client/SandboxGwtTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-basic/src/test/java/com/gwtplatform/samples/basic/client/SandboxJukitoTest.java
+++ b/gwtp-samples/gwtp-sample-basic/src/test/java/com/gwtplatform/samples/basic/client/SandboxJukitoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-crawler-service/pom.xml
+++ b/gwtp-samples/gwtp-sample-crawler-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.gwtplatform</groupId>
         <artifactId>gwtp-samples</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>gwtp-sample-crawler-service</artifactId>

--- a/gwtp-samples/gwtp-sample-crawler-service/src/main/java/com/gwtplatform/samples/crawlerservice/server/CrawlerGuiceServletContextListener.java
+++ b/gwtp-samples/gwtp-sample-crawler-service/src/main/java/com/gwtplatform/samples/crawlerservice/server/CrawlerGuiceServletContextListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-crawler-service/src/main/java/com/gwtplatform/samples/crawlerservice/server/CrawlerModule.java
+++ b/gwtp-samples/gwtp-sample-crawler-service/src/main/java/com/gwtplatform/samples/crawlerservice/server/CrawlerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/pom.xml
+++ b/gwtp-samples/gwtp-sample-mobile/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.gwtplatform</groupId>
         <artifactId>gwtp-samples</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>gwtp-sample-mobile</artifactId>

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/AbstractApplicationPresenter.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/AbstractApplicationPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationDesktopModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationDesktopModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationDesktopPresenter.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationDesktopPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationDesktopView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationDesktopView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationMobileModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationMobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationMobilePresenter.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationMobilePresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationMobileView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationTabletModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationTabletModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationTabletPresenter.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationTabletPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationTabletView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationTabletView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/ApplicationUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsMobileView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsPresenter.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsTabletView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsTabletView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/breadcrumbs/BreadcrumbsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductMobileView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductPresenter.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductTabletView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductTabletView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/product/ProductView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsMobileView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsMobileView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsPresenter.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsTabletView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsTabletView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsView.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/application/products/ProductsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/DesktopModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/DesktopModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/MobileModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/MobileModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/PhoneGapLocalModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/PhoneGapLocalModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/PhoneGapModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/PhoneGapModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/PhoneGapRemoteModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/PhoneGapRemoteModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/SharedModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/SharedModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/SharedModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/SharedModule.java
@@ -16,10 +16,7 @@
 
 package com.gwtplatform.samples.mobile.client.gin;
 
-import com.gwtplatform.mvp.client.annotations.DefaultPlace;
-import com.gwtplatform.mvp.client.annotations.ErrorPlace;
 import com.gwtplatform.mvp.client.annotations.GaAccount;
-import com.gwtplatform.mvp.client.annotations.UnauthorizedPlace;
 import com.gwtplatform.mvp.client.gin.AbstractPresenterModule;
 import com.gwtplatform.mvp.client.gin.DefaultModule;
 import com.gwtplatform.samples.mobile.client.place.NameTokens;
@@ -27,12 +24,11 @@ import com.gwtplatform.samples.mobile.client.place.NameTokens;
 public class SharedModule extends AbstractPresenterModule {
     @Override
     protected void configure() {
-        install(new DefaultModule());
-
-        // DefaultPlaceManager Places
-        bindConstant().annotatedWith(DefaultPlace.class).to(NameTokens.homePage);
-        bindConstant().annotatedWith(ErrorPlace.class).to(NameTokens.homePage);
-        bindConstant().annotatedWith(UnauthorizedPlace.class).to(NameTokens.homePage);
+        install(new DefaultModule.Builder()
+                .defaultPlace(NameTokens.homePage)
+                .errorPlace(NameTokens.homePage)
+                .unauthorizedPlace(NameTokens.homePage)
+                .build());
 
         // Google Analytics
         bindConstant().annotatedWith(GaAccount.class).to("UA-8319339-6");

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/TabletModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/gin/TabletModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/place/NameTokens.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/place/NameTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/place/ParameterTokens.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/client/place/ParameterTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/ProductDatabase.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/ProductDatabase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/dispatch/GetProductHandler.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/dispatch/GetProductHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/dispatch/GetProductListHandler.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/dispatch/GetProductListHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/guice/DispatchServletModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/guice/DispatchServletModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/guice/GuiceServletConfig.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/guice/GuiceServletConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/guice/ServerModule.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/server/guice/ServerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductAction.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductListAction.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductListAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductListResult.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductListResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductResult.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/GetProductResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/Product.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/main/java/com/gwtplatform/samples/mobile/shared/dispatch/Product.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/test/java/com/gwtplatform/samples/mobile/client/SandboxGwtTest.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/test/java/com/gwtplatform/samples/mobile/client/SandboxGwtTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-mobile/src/test/java/com/gwtplatform/samples/mobile/client/SandboxJukitoTest.java
+++ b/gwtp-samples/gwtp-sample-mobile/src/test/java/com/gwtplatform/samples/mobile/client/SandboxJukitoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/pom.xml
+++ b/gwtp-samples/gwtp-sample-nested/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.gwtplatform</groupId>
         <artifactId>gwtp-samples</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>gwtp-sample-nested</artifactId>

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ApplicationModule.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ApplicationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ApplicationPresenter.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ApplicationPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ApplicationView.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ApplicationView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/aboutus/AboutUsPresenter.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/aboutus/AboutUsPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/aboutus/AboutUsView.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/aboutus/AboutUsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/contact/ContactPresenter.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/contact/ContactPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/contact/ContactPresenterBase.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/contact/ContactPresenterBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/contact/ContactView.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/contact/ContactView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/home/HomePresenter.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/home/HomePresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/home/HomeView.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/home/HomeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ui/MainMenu.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/application/ui/MainMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/gin/ClientModule.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/gin/ClientModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -16,12 +16,8 @@
 
 package com.gwtplatform.samples.nested.client.gin;
 
-import com.gwtplatform.mvp.client.annotations.DefaultPlace;
-import com.gwtplatform.mvp.client.annotations.ErrorPlace;
-import com.gwtplatform.mvp.client.annotations.UnauthorizedPlace;
 import com.gwtplatform.mvp.client.gin.AbstractPresenterModule;
 import com.gwtplatform.mvp.client.gin.DefaultModule;
-import com.gwtplatform.mvp.client.proxy.DefaultPlaceManager;
 import com.gwtplatform.samples.nested.client.application.ApplicationModule;
 import com.gwtplatform.samples.nested.client.place.NameTokens;
 import com.gwtplatform.samples.nested.client.resources.ResourceLoader;
@@ -29,13 +25,12 @@ import com.gwtplatform.samples.nested.client.resources.ResourceLoader;
 public class ClientModule extends AbstractPresenterModule {
     @Override
     protected void configure() {
-        install(new DefaultModule(DefaultPlaceManager.class));
+        install(new DefaultModule.Builder()
+                .defaultPlace(NameTokens.homePage)
+                .errorPlace(NameTokens.homePage)
+                .unauthorizedPlace(NameTokens.homePage)
+                .build());
         install(new ApplicationModule());
-
-        // DefaultPlaceManager Places
-        bindConstant().annotatedWith(DefaultPlace.class).to(NameTokens.homePage);
-        bindConstant().annotatedWith(ErrorPlace.class).to(NameTokens.homePage);
-        bindConstant().annotatedWith(UnauthorizedPlace.class).to(NameTokens.homePage);
 
         bind(ResourceLoader.class).asEagerSingleton();
     }

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/place/NameTokens.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/place/NameTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/resources/AppResources.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/resources/AppResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/resources/ResourceLoader.java
+++ b/gwtp-samples/gwtp-sample-nested/src/main/java/com/gwtplatform/samples/nested/client/resources/ResourceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/test/java/com/gwtplatform/samples/nested/client/SandboxGwtTest.java
+++ b/gwtp-samples/gwtp-sample-nested/src/test/java/com/gwtplatform/samples/nested/client/SandboxGwtTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-nested/src/test/java/com/gwtplatform/samples/nested/client/SandboxJukitoTest.java
+++ b/gwtp-samples/gwtp-sample-nested/src/test/java/com/gwtplatform/samples/nested/client/SandboxJukitoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/MyBootstrapper.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/MyBootstrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationModule.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationPresenter.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationView.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/ApplicationView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page1/Page1Module.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page1/Page1Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page1/Page1Presenter.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page1/Page1Presenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page1/Page1View.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page1/Page1View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page2/Page2Module.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page2/Page2Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page2/Page2Presenter.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page2/Page2Presenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page2/Page2View.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/application/page2/Page2View.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/gin/ClientModule.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/gin/ClientModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -16,9 +16,6 @@
 
 package com.gwtplatform.samples.polymer.client.gin;
 
-import com.gwtplatform.mvp.client.annotations.DefaultPlace;
-import com.gwtplatform.mvp.client.annotations.ErrorPlace;
-import com.gwtplatform.mvp.client.annotations.UnauthorizedPlace;
 import com.gwtplatform.mvp.client.gin.AbstractPresenterModule;
 import com.gwtplatform.mvp.client.gin.DefaultModule;
 import com.gwtplatform.samples.polymer.client.application.ApplicationModule;
@@ -27,12 +24,11 @@ import com.gwtplatform.samples.polymer.client.place.NameTokens;
 public class ClientModule extends AbstractPresenterModule {
     @Override
     protected void configure() {
-        install(new DefaultModule.Builder().build());
+        install(new DefaultModule.Builder()
+                .defaultPlace(NameTokens.PAGE1)
+                .errorPlace(NameTokens.PAGE1)
+                .unauthorizedPlace(NameTokens.PAGE2)
+                .build());
         install(new ApplicationModule());
-
-        // DefaultPlaceManager Places
-        bindConstant().annotatedWith(DefaultPlace.class).to(NameTokens.PAGE1);
-        bindConstant().annotatedWith(ErrorPlace.class).to(NameTokens.PAGE1);
-        bindConstant().annotatedWith(UnauthorizedPlace.class).to(NameTokens.PAGE2);
     }
 }

--- a/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/place/NameTokens.java
+++ b/gwtp-samples/gwtp-sample-polymer/src/main/java/com/gwtplatform/samples/polymer/client/place/NameTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/pom.xml
+++ b/gwtp-samples/gwtp-sample-tab/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.gwtplatform</groupId>
         <artifactId>gwtp-samples</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>gwtp-sample-tab</artifactId>

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ApplicationModule.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ApplicationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ApplicationPresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ApplicationPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ApplicationView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ApplicationView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/adminarea/AdminAreaPresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/adminarea/AdminAreaPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/adminarea/AdminAreaView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/adminarea/AdminAreaView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/adminarea/TabDataExt.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/adminarea/TabDataExt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/dialog/DialogSamplePresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/dialog/DialogSamplePresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/dialog/DialogSampleView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/dialog/DialogSampleView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogPresenterWidget.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogPresenterWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogSubTabPresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogSubTabPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogSubTabUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogSubTabUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogSubTabView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogSubTabView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/globaldialog/GlobalDialogView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/home/HomePresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/home/HomePresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/home/HomePresenterBase.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/home/HomePresenterBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/home/HomeView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/home/HomeView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homeinfo/HomeInfoPresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homeinfo/HomeInfoPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homeinfo/HomeInfoView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homeinfo/HomeInfoView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homenews/HomeNewsPresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homenews/HomeNewsPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homenews/HomeNewsUiHandler.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homenews/HomeNewsUiHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homenews/HomeNewsView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/homenews/HomeNewsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/infopopup/InfoPopupPresenterWidget.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/infopopup/InfoPopupPresenterWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/infopopup/InfoPopupView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/infopopup/InfoPopupView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogPresenterWidget.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogPresenterWidget.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogSubTabPresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogSubTabPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogSubTabUihandlers.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogSubTabUihandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogSubTabView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogSubTabView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/localdialog/LocalDialogView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/settings/SettingsPresenter.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/settings/SettingsPresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/settings/SettingsUiHandlers.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/settings/SettingsUiHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/settings/SettingsView.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/settings/SettingsView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/UiModule.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/UiModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/linkmenu/LinkMenu.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/linkmenu/LinkMenu.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/BaseTab.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/BaseTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/BaseTabPanel.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/BaseTabPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/RoundTab.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/RoundTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/RoundTabPanel.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/RoundTabPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/SimpleTab.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/SimpleTab.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/SimpleTabPanel.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/SimpleTabPanel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/TabFactory.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/application/ui/tabs/TabFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/gin/ClientModule.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/gin/ClientModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -17,13 +17,9 @@
 package com.gwtplatform.samples.tab.client.gin;
 
 import com.google.inject.Singleton;
-import com.gwtplatform.mvp.client.annotations.DefaultPlace;
-import com.gwtplatform.mvp.client.annotations.ErrorPlace;
 import com.gwtplatform.mvp.client.annotations.GaAccount;
-import com.gwtplatform.mvp.client.annotations.UnauthorizedPlace;
 import com.gwtplatform.mvp.client.gin.AbstractPresenterModule;
 import com.gwtplatform.mvp.client.gin.DefaultModule;
-import com.gwtplatform.mvp.client.proxy.DefaultPlaceManager;
 import com.gwtplatform.samples.tab.client.application.ApplicationModule;
 import com.gwtplatform.samples.tab.client.place.NameTokens;
 import com.gwtplatform.samples.tab.client.security.CurrentUser;
@@ -32,16 +28,15 @@ import com.gwtplatform.samples.tab.client.security.IsAdminGatekeeper;
 public class ClientModule extends AbstractPresenterModule {
     @Override
     protected void configure() {
-        install(new DefaultModule(DefaultPlaceManager.class));
+        install(new DefaultModule.Builder()
+                .defaultPlace(NameTokens.homeNewsPage)
+                .errorPlace(NameTokens.homeNewsPage)
+                .unauthorizedPlace(NameTokens.homeNewsPage)
+                .build());
         install(new ApplicationModule());
 
         bind(CurrentUser.class).in(Singleton.class);
         bind(IsAdminGatekeeper.class).in(Singleton.class);
-
-        // DefaultPlaceManager Constants
-        bindConstant().annotatedWith(DefaultPlace.class).to(NameTokens.homeNewsPage);
-        bindConstant().annotatedWith(ErrorPlace.class).to(NameTokens.homeNewsPage);
-        bindConstant().annotatedWith(UnauthorizedPlace.class).to(NameTokens.homeNewsPage);
 
         // Google Analytics
         bindConstant().annotatedWith(GaAccount.class).to("UA-8319339-6");

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/gin/GinjectorExtension.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/gin/GinjectorExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/gin/ResourceLoader.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/gin/ResourceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/place/NameTokens.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/place/NameTokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/AppConstants.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/AppConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/AppMessages.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/AppMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/AppResources.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/AppResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/DialogResources.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/DialogResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/TabsResources.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/TabsResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/Variables.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/resources/Variables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/CurrentUser.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/CurrentUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/CurrentUserChangedEvent.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/CurrentUserChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/CurrentUserChangedHandler.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/CurrentUserChangedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/IsAdminGatekeeper.java
+++ b/gwtp-samples/gwtp-sample-tab/src/main/java/com/gwtplatform/samples/tab/client/security/IsAdminGatekeeper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/test/java/com/gwtplatform/samples/tab/client/SandboxGwtTest.java
+++ b/gwtp-samples/gwtp-sample-tab/src/test/java/com/gwtplatform/samples/tab/client/SandboxGwtTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/gwtp-sample-tab/src/test/java/com/gwtplatform/samples/tab/client/SandboxJukitoTest.java
+++ b/gwtp-samples/gwtp-sample-tab/src/test/java/com/gwtplatform/samples/tab/client/SandboxJukitoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/gwtp-samples/pom.xml
+++ b/gwtp-samples/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.gwtplatform</groupId>
     <artifactId>gwtp-samples</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.5-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>GWT-Platform Samples</name>
     <inceptionYear>2010</inceptionYear>
@@ -89,7 +89,7 @@
         <maven-checkstyle-plugin.version>2.14</maven-checkstyle-plugin.version>
 
         <checkstyle.version>6.3</checkstyle.version>
-        <arcbees-checkstyle.version>1.1</arcbees-checkstyle.version>
+        <arcbees-checkstyle.version>1.2</arcbees-checkstyle.version>
 
         <!-- testing -->
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
ad75afd contains actual changes.
The other commit replaces copyright headers starting with `/**` to `/*`: I got tired of IntelliJ's auto format  screwing up the license header.