### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#GWTP-Samples
+# GWTP-Samples
 Project samples display GWT-Platform features configuration and uses.
 
-##GWTP Reference
+## GWTP Reference
 * [GWTP Custom Google Search](http://www.google.com/cse/home?cx=011138278718949652927:5yuja8xc600) - Search GWTP documentation, wiki and thread collections.
 * [GWTP Home](https://github.com/ArcBees/GWTP) - Find the GWT-Platform home here.
 * [GWTP Documentation](https://github.com/arcbees/gwtp/wiki) - Find out how to use GWT-Platform here.
 * [GWTP Archetypes](https://github.com/ArcBees/ArcBees-archetypes/tree/master/archetypes) - Start a project from a template here.
 
-##Community
+## Community
 * [Join the GWT-Platform G+ Community](https://plus.google.com/communities/113139554133824081251) - See whats happening in the community.
 * [GWTP Google Group](https://groups.google.com/forum/?fromgroups#!forum/gwt-platform) - Ask for help here.
 
-##Demos
+## Demos
 <table>
   <tr>
     <th>Sample</th>
@@ -45,10 +45,10 @@ Project samples display GWT-Platform features configuration and uses.
   </tr>
 </table>
 
-##License
+## License
 * GWTP is freely distributable under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html)
 
-##Thanks to
+## Thanks to
 [![Arcbees.com](http://i.imgur.com/HDf1qfq.png)](http://arcbees.com)
 
 [![Atlassian](http://i.imgur.com/BKkj8Rg.png)](https://www.atlassian.com/)

--- a/carstore/README.md
+++ b/carstore/README.md
@@ -1,25 +1,25 @@
-#Car Store
+# Car Store
 This is a test bed for the GWTP features. 
 
 Login password for the login feature is: admin/qwerty
 
-##Running Tests
+## Running Tests
 
-###Prerequisites
+### Prerequisites
 We use chromedriver for running integration tests. You'll need chromedriver on your path.
 [Download it here.](https://sites.google.com/a/chromium.org/chromedriver/)
 
-###Maven integration tests
+### Maven integration tests
 Running the tests using Maven
 `mvn clean verify -Pintegration-test`
 
-###IDE Integration tests
+### IDE Integration tests
 Running tests using the IDE
 `mvn clean compile gwt:compile gae:run -Pintegration-test`
 
-##Reference
+## Reference
 * [Form Factors](https://github.com/ArcBees/GWTP/wiki/Form-Factors)
 * [PhoneGap support](https://github.com/ArcBees/GWTP/wiki/Phonegap-support)
 
-##App Engine
+## App Engine
 * [gwtp-carstore.appspot.com](http://gwtp-carstore.appspot.com/)

--- a/gwtp-samples/README.md
+++ b/gwtp-samples/README.md
@@ -1,8 +1,8 @@
-#GWTP Samples
+# GWTP Samples
 
-##[GWTP Home](https://github.com/ArcBees/GWTP)
+## [GWTP Home](https://github.com/ArcBees/GWTP)
 
-##Demos
+## Demos
 <table>
   <tr>
     <th>Sample</th>

--- a/gwtp-samples/gwtp-sample-basic-spring/README.md
+++ b/gwtp-samples/gwtp-sample-basic-spring/README.md
@@ -1,6 +1,6 @@
-#Basic GWTP Sample using Spring
+# Basic GWTP Sample using Spring
 
-##[GWTP Home](https://github.com/ArcBees/GWTP)
+## [GWTP Home](https://github.com/ArcBees/GWTP)
 
-##Demo
+## Demo
 http://gwtp-sample-basic-spring.appspot.com

--- a/gwtp-samples/gwtp-sample-basic/README.md
+++ b/gwtp-samples/gwtp-sample-basic/README.md
@@ -1,6 +1,6 @@
-#Basic GWTP Sample using Guice
+# Basic GWTP Sample using Guice
 
-##[GWTP Home](https://github.com/ArcBees/GWTP)
+## [GWTP Home](https://github.com/ArcBees/GWTP)
 
-##Demo
+## Demo
 http://gwtp-sample-basic.appspot.com

--- a/gwtp-samples/gwtp-sample-crawler-service/README.md
+++ b/gwtp-samples/gwtp-sample-crawler-service/README.md
@@ -1,3 +1,3 @@
-#GWTP Crawler Sample
+# GWTP Crawler Sample
 
-##[GWTP Home](https://github.com/ArcBees/GWTP)
+## [GWTP Home](https://github.com/ArcBees/GWTP)

--- a/gwtp-samples/gwtp-sample-mobile/README.md
+++ b/gwtp-samples/gwtp-sample-mobile/README.md
@@ -1,18 +1,18 @@
-#GWTP Mobile Sample
+# GWTP Mobile Sample
 
-##[GWTP Home](https://github.com/ArcBees/GWTP)
+## [GWTP Home](https://github.com/ArcBees/GWTP)
 
-##Demo
+## Demo
 http://gwtp-sample-mobile.appspot.com
 
-##PhoneGap Debugging Build
+## PhoneGap Debugging Build
 To run the phonegap profile locally in the mobile sample you must first compile the sample using:
 
 * Run `mvn clean install -Pphonegap-local`
 * Then run the GAE server using: `mvn gae:run`
 * Then open your browser to `http://localhost:8080`
 
-###PhoneGap Device Build
+### PhoneGap Device Build
 Generically speaking the PhoneGap build wraps up the GWT module client side and builds a native version. 
 No server side classes will be needed and can be deleted before zipping it and uploading it to Adobe Bd. 
 We do this by exploding the war file and deleting the server side and testing the web mode.
@@ -22,7 +22,7 @@ We do this by exploding the war file and deleting the server side and testing th
 * Delete web-inf and meta-inf folders. No server side folders will be needed for native mobile client.
 * Zip up client side files into yourname.zip for uploading to adobe bd.
 
-###Deploy using Adobe Build
+### Deploy using Adobe Build
 * Goto https://build.phonegap.com/apps
 * Zip up app client side source only
 * Create development Android key like this. Do not loose your key. Do not forget your password/passphrase. 
@@ -31,5 +31,5 @@ keytool -genkey -v -keystore brandon_donnelson.keystore -alias branflake2267@gma
 * Upload zip file of client side source
 * Download and test the apk. Be sure the android sdk is installed locally.
 
-##Contributor Notes
+## Contributor Notes
 1. run 'mvn generate-sources' - this will generate some of the annotated classes needed

--- a/gwtp-samples/gwtp-sample-nested/README.md
+++ b/gwtp-samples/gwtp-sample-nested/README.md
@@ -1,6 +1,6 @@
-#GWTP Nested Sample
+# GWTP Nested Sample
 
-##[GWTP Home](https://github.com/ArcBees/GWTP)
+## [GWTP Home](https://github.com/ArcBees/GWTP)
 
-##Demo
+## Demo
 http://gwtp-sample-nested.appspot.com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
